### PR TITLE
Create Dockerfile and docker's compose.yml file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM eclipse-temurin:8 AS j8-builder
+ENV APP_SRC=/src
+WORKDIR $APP_SRC
+COPY gradlew build.gradle settings.gradle $APP_SRC
+
+COPY gradle $APP_SRC/gradle
+RUN ls -lha
+COPY --chmod=0755 . $APP_SRC
+
+RUN $APP_SRC/gradlew shadowJar
+
+FROM eclipse-temurin:8
+WORKDIR /data
+RUN mkdir /opt/app
+COPY --from=j8-builder /src/build/libs/*.jar /opt/app/nanolimbo.jar
+EXPOSE 65535
+CMD ["java", "-jar", "/opt/app/nanolimbo.jar"]

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,24 @@
+services:
+  nanolimbo:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: nanolimbo
+    container_name: nanolimbo
+    networks:
+      default: null
+    ports:
+    - mode: ingress
+      target: 65535
+      published: "65535"
+      protocol: tcp
+    restart: unless-stopped
+    volumes:
+    - type: bind
+      source: nanolimbo_data
+      target: /data
+      bind:
+        create_host_path: true
+networks:
+  default:
+    name: nanolimbo_default


### PR DESCRIPTION
This PR provides a Dockerfile capable of compiling the source code with just doing `DOCKER_BUILDKIT=1 docker build` and running it inside of a container.
Together with it is bundled a compose.yml file, which requires Docker CE to be installed (not the same as regular distro provided docker, haven't tested with it though).
This can easily be used to create an image for the end user to pull from the docker registry.