### PR TITLE
Implement string reading limits

### DIFF
--- a/src/main/java/ua/nanit/limbo/protocol/packets/PacketHandshake.java
+++ b/src/main/java/ua/nanit/limbo/protocol/packets/PacketHandshake.java
@@ -55,7 +55,7 @@ public class PacketHandshake implements PacketIn {
             this.version = Version.UNDEFINED;
         }
 
-        this.host = msg.readString();
+        this.host = msg.readString(261);
         this.port = msg.readUnsignedShort();
         this.nextState = State.getById(msg.readVarInt());
     }

--- a/src/main/java/ua/nanit/limbo/protocol/packets/login/PacketLoginStart.java
+++ b/src/main/java/ua/nanit/limbo/protocol/packets/login/PacketLoginStart.java
@@ -33,7 +33,7 @@ public class PacketLoginStart implements PacketIn {
 
     @Override
     public void decode(ByteMessage msg, Version version) {
-        this.username = msg.readString();
+        this.username = msg.readString(16);
     }
 
     @Override


### PR DESCRIPTION
Ensures that the strings we're reading aren't too long.

I've added string length limits to the Handshake packet and LoginStart packet.