### PR TITLE
General protocol sanity fixes

### DIFF
--- a/src/main/java/ua/nanit/limbo/protocol/ByteMessage.java
+++ b/src/main/java/ua/nanit/limbo/protocol/ByteMessage.java
@@ -125,6 +125,10 @@ public class ByteMessage extends ByteBuf {
 
     public byte[] readBytesArray() {
         int length = readVarInt();
+        return readBytesArray(length);
+    }
+
+    public byte[] readBytesArray(int length) {
         byte[] array = new byte[length];
         buf.readBytes(array);
         return array;

--- a/src/main/java/ua/nanit/limbo/protocol/packets/login/PacketLoginStart.java
+++ b/src/main/java/ua/nanit/limbo/protocol/packets/login/PacketLoginStart.java
@@ -44,8 +44,8 @@ public class PacketLoginStart implements PacketIn {
     public void decode(ByteMessage msg, Version version) {
         this.username = msg.readString();
 
-        if (version.compareTo(Version.V1_19) >= 0) {
-            if (version.compareTo(Version.V1_19_3) < 0) {
+        if (version.moreOrEqual(Version.V1_19)) {
+            if (version.less(Version.V1_19_3)) {
                 if (msg.readBoolean()) {
                     msg.readLong(); // expiry
                     msg.readBytesArray(); // key
@@ -53,12 +53,12 @@ public class PacketLoginStart implements PacketIn {
                 }
             }
 
-            if (version.compareTo(Version.V1_20_2) >= 0) {
+            if (version.moreOrEqual(Version.V1_20_2)) {
                 uuid = msg.readUuid();
                 return;
             }
 
-            if (version.compareTo(Version.V1_19_1) >= 0) {
+            if (version.moreOrEqual(Version.V1_19_1)) {
                 if (msg.readBoolean()) {
                     uuid = msg.readUuid();
                 }

--- a/src/main/java/ua/nanit/limbo/protocol/packets/login/PacketLoginStart.java
+++ b/src/main/java/ua/nanit/limbo/protocol/packets/login/PacketLoginStart.java
@@ -53,13 +53,8 @@ public class PacketLoginStart implements PacketIn {
                 }
             }
 
-            if (version.moreOrEqual(Version.V1_20_2)) {
-                uuid = msg.readUuid();
-                return;
-            }
-
             if (version.moreOrEqual(Version.V1_19_1)) {
-                if (msg.readBoolean()) {
+                if (version.moreOrEqual(Version.V1_20_2) || msg.readBoolean()) {
                     uuid = msg.readUuid();
                 }
             }

--- a/src/main/java/ua/nanit/limbo/protocol/packets/login/PacketLoginStart.java
+++ b/src/main/java/ua/nanit/limbo/protocol/packets/login/PacketLoginStart.java
@@ -17,23 +17,53 @@
 
 package ua.nanit.limbo.protocol.packets.login;
 
+import org.jetbrains.annotations.Nullable;
 import ua.nanit.limbo.connection.ClientConnection;
 import ua.nanit.limbo.protocol.ByteMessage;
 import ua.nanit.limbo.protocol.PacketIn;
 import ua.nanit.limbo.protocol.registry.Version;
 import ua.nanit.limbo.server.LimboServer;
 
+import java.util.UUID;
+
+// https://github.com/jonesdevelopment/sonar/blob/main/common/src/main/java/xyz/jonesdev/sonar/common/fallback/protocol/packets/login/LoginStartPacket.java
 public class PacketLoginStart implements PacketIn {
 
     private String username;
+    private @Nullable UUID uuid;
 
     public String getUsername() {
         return username;
     }
 
+    public @Nullable UUID getUuid() {
+        return uuid;
+    }
+
     @Override
     public void decode(ByteMessage msg, Version version) {
         this.username = msg.readString();
+
+        if (version.compareTo(Version.V1_19) >= 0) {
+            if (version.compareTo(Version.V1_19_3) < 0) {
+                if (msg.readBoolean()) {
+                    msg.readLong(); // expiry
+                    msg.readBytesArray(); // key
+                    msg.readBytesArray(4096); // signature
+                }
+            }
+
+            if (version.compareTo(Version.V1_20_2) >= 0) {
+                uuid = msg.readUuid();
+                return;
+            }
+
+            if (version.compareTo(Version.V1_19_1) >= 0) {
+                if (msg.readBoolean()) {
+                    uuid = msg.readUuid();
+                }
+            }
+        }
     }
 
     @Override

--- a/src/main/java/ua/nanit/limbo/protocol/registry/State.java
+++ b/src/main/java/ua/nanit/limbo/protocol/registry/State.java
@@ -108,11 +108,6 @@ public enum State {
             );
 
             serverBound.register(
-                    PacketPluginMessage::new,
-                    map(0x01, V1_20_2, V1_20_3),
-                    map(0x02, V1_20_2, V1_21)
-            );
-            serverBound.register(
                     PacketFinishConfiguration::new,
                     map(0x02, V1_20_2, V1_20_3),
                     map(0x03, V1_20_5, V1_21)


### PR DESCRIPTION
- Fixes `LoginStart` packet not being decoded correctly
- Fixes `PluginMessage` packet mistakenly being registered for serverbound
- Fixes several potential exploits by adding sanity checks to the protocol