### PR TITLE
Fix legacy/bungeeguard forwarding causing improper (offline) player UUID.

### DIFF
--- a/src/main/java/ua/nanit/limbo/connection/PacketHandler.java
+++ b/src/main/java/ua/nanit/limbo/connection/PacketHandler.java
@@ -100,7 +100,9 @@ public class PacketHandler {
 
         if (!server.getConfig().getInfoForwarding().isModern()) {
             conn.getGameProfile().setUsername(packet.getUsername());
-            conn.getGameProfile().setUuid(UuidUtil.getOfflineModeUuid(packet.getUsername()));
+            if (conn.getGameProfile().getUuid() == null) {
+                conn.getGameProfile().setUuid(UuidUtil.getOfflineModeUuid(packet.getUsername()));
+            }
         }
 
         conn.fireLoginSuccess();


### PR DESCRIPTION
Some servers I know use NanoLimbo at it's core, but forked. And I'm a developer on one of them.
Was doing a fork to add some functionality to it, like logging in to server for my infrastructure etc. and noticed this bug.
This can cause some players to loose their data, if you use this UUID anywhere in the limbo code, even if it's up to plugin developers to resolve this issue.