### PR TITLE
switch entity id to 1

### DIFF
--- a/src/main/java/ua/nanit/limbo/connection/PacketSnapshots.java
+++ b/src/main/java/ua/nanit/limbo/connection/PacketSnapshots.java
@@ -97,7 +97,7 @@ public class PacketSnapshots {
         DimensionType dimensionType = server.getConfig().getDimensionType();
         DimensionRegistry dimensionRegistry = server.getDimensionRegistry();
         VersionedDimension versionedDimension = dimensionType.createVersionedDimension(dimensionRegistry);
-        joinGame.setEntityId(0);
+        joinGame.setEntityId(1);
         joinGame.setEnableRespawnScreen(true);
         joinGame.setFlat(false);
         joinGame.setGameMode(server.getConfig().getGameMode());


### PR DESCRIPTION
fixes several client side bugs that occur on backends when a player has an entity id of 0, like broken firework elytra boosting https://bugs.mojang.com/browse/MC/issues/MC-111480 

this only affects bungee networks that use nanolimbo as the first server players join (like an auth server). sub 1.16 clients switch servers from a respawn packet instead of a login packet which means the player's entity id never gets updated. so whatever entity id nanolimbo assigns will stick on the client for their entire session across all backend servers, which will cause these bugs everywhere else.